### PR TITLE
Add emulated memory start location support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.idea/
 /cmake-build-*/
+/.vs
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,17 @@ project(prime_watch_external)
 set(CMAKE_CXX_STANDARD 11)
 
 add_definitions(-DPRIME_DUMP_JSON=1)
+add_definitions(-DPW_USE_LOOPBACK)
 add_subdirectory(PrimeMemoryDumping)
 include_directories(PrimeMemoryDumping/common)
 include_directories(PrimeMemoryDumping/)
 
-set(SOURCE_FILES main.cpp
+set(SOURCE_FILES main.cpp common.cpp
         PrimeMemoryDumping/prime1/Prime1JsonDumper.cpp
         PrimeMemoryDumping/common/MemoryBuffer.cpp)
 
 if (WIN32 OR CYGWIN)
+    add_definitions(-DWIN32_LEAN_AND_MEAN)
     message("Windows target")
     set(SOURCE_FILES ${SOURCE_FILES} windump.cpp)
 endif ()
@@ -20,3 +22,7 @@ endif ()
 SET(BUILD_SHARED_LIBRARIES OFF)
 SET(CMAKE_EXE_LINKER_FLAGS "-static")
 add_executable(prime_watch_external ${SOURCE_FILES})
+
+if (WIN32)
+    target_link_libraries(prime_watch_external wsock32 ws2_32)
+endif ()

--- a/common.cpp
+++ b/common.cpp
@@ -1,0 +1,39 @@
+#ifdef WIN32
+#include <intrin.h>
+#include <cstdint>
+
+uint32_t beToHost32(uint32_t bigEndian) {
+    return _byteswap_ulong(bigEndian);
+}
+
+uint32_t hostToBe32(uint32_t value) {
+    return _byteswap_ulong(value);
+}
+
+uint64_t beToHost64(uint64_t bigEndian) {
+    return _byteswap_uint64(bigEndian);
+}
+
+uint64_t hostToBe64(uint64_t value) {
+    return _byteswap_uint64(value);
+}
+
+#else
+
+uint32_t beToHost32(uint32_t bigEndian) {
+    return be32toh(bigEndian);
+}
+
+uint32_t hostToBe32(uint32_t value) {
+    return htobe32(value);
+}
+
+uint64_t beToHost64(uint64_t bigEndian) {
+    return be64toh(bigEndian);
+}
+
+uint64_t hostToBe64(uint64_t value) {
+    return htobe64(value);
+}
+
+#endif

--- a/common.h
+++ b/common.h
@@ -1,8 +1,15 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-void handleClient(int sock);
-void wootWootGetRoot();
+#ifdef WIN32
+#   include <cstdint>
+#endif
+
 void findAndAttachProcess();
+
+uint32_t beToHost32(uint32_t bigEndian);
+uint32_t hostToBe32(uint32_t value);
+uint64_t beToHost64(uint64_t bigEndian);
+uint64_t hostToBe64(uint64_t value);
 
 #endif

--- a/windump.cpp
+++ b/windump.cpp
@@ -1,35 +1,70 @@
 #include "common.h"
 
-#define WIN32_LEAN_AND_MEAN
-
 #include <windows.h>
 #include <tlhelp32.h>
+#include <psapi.h>
 
 #include <iostream>
 #include <cstring>
 
 using namespace std;
 
-void wootWootGetRoot() {
-  HANDLE handle;
-  LUID luid;
-  TOKEN_PRIVILEGES privileges;
-
-  OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &handle);
-
-  LookupPrivilegeValue(NULL, SE_DEBUG_NAME, &luid);
-
-  privileges.PrivilegeCount = 1;
-  privileges.Privileges[0].Luid = luid;
-  privileges.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-
-  AdjustTokenPrivileges(handle, false, &privileges, sizeof(privileges), NULL, NULL);
-
-  CloseHandle(handle);
-}
-
 HANDLE dolphinProcHandle = 0;
-void *offset = (void *) 0x7FFF0000;
+uint64_t emuRAMAddressStart = 0;
+bool MEM2Present = false;
+
+// Shamelessly ripped from Dolphin-memory-engine
+// https://github.com/aldelaro5/Dolphin-memory-engine/blob/master/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
+// Returns true if we found and set emuRAMAddressStart
+bool getEmuRAMAddressStart() {
+  if (!dolphinProcHandle)
+    return false;
+
+  MEMORY_BASIC_INFORMATION info;
+  bool MEM1Found = false;
+  for (unsigned char* p = nullptr; VirtualQueryEx(dolphinProcHandle, p, &info, sizeof(info)) == sizeof(info); p += info.RegionSize) {
+    if (MEM1Found) {
+      uint64_t regionBaseAddress = 0;
+      memcpy(&regionBaseAddress, &(info.BaseAddress), sizeof(info.BaseAddress));
+      if (regionBaseAddress == emuRAMAddressStart + 0x10000000) {
+        // View the comment for MEM1
+        PSAPI_WORKING_SET_EX_INFORMATION wsInfo;
+        wsInfo.VirtualAddress = info.BaseAddress;
+        if (QueryWorkingSetEx(dolphinProcHandle, &wsInfo, sizeof(PSAPI_WORKING_SET_EX_INFORMATION))) {
+          if (wsInfo.VirtualAttributes.Valid)
+            MEM2Present = true;
+        }
+
+        break;
+      } else if (regionBaseAddress > emuRAMAddressStart + 0x10000000) {
+        MEM2Present = false;
+        break;
+      }
+
+      continue;
+    }
+
+    if (info.RegionSize == 0x2000000 && info.Type == MEM_MAPPED) {
+      // Here, it's likely the right page, but it can happen that multiple pages with these criteria
+      // exists and have nothing to do with the emulated memory. Only the right page has valid
+      // working set information so an additional check is required that it is backed by physical memory.
+      PSAPI_WORKING_SET_EX_INFORMATION wsInfo;
+      wsInfo.VirtualAddress = info.BaseAddress;
+      if (QueryWorkingSetEx(dolphinProcHandle, &wsInfo, sizeof(PSAPI_WORKING_SET_EX_INFORMATION))) {
+        if (wsInfo.VirtualAttributes.Valid) {
+          memcpy(&emuRAMAddressStart, &(info.BaseAddress), sizeof(info.BaseAddress));
+          MEM1Found = true;
+          cout << "Found ram start: " << emuRAMAddressStart << endl;
+        }
+      }
+    }
+  }
+
+  if (!emuRAMAddressStart)
+    return false; // Dolphin is running, but the emulation hasn't started
+
+  return true;
+}
 
 void findAndAttachProcess() {
   PROCESSENTRY32 entry;
@@ -42,7 +77,7 @@ void findAndAttachProcess() {
     while (Process32Next(snapshot, &entry) == TRUE) {
       if (strncmp(entry.szExeFile, "Dolphin.exe", 10) == 0) {
         cout << "Found Dolphin, PID " << entry.th32ProcessID << endl;
-        dolphinProcHandle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, entry.th32ProcessID);
+        dolphinProcHandle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION | PROCESS_VM_READ, FALSE, entry.th32ProcessID);
         found = true;
         break;
       }
@@ -55,10 +90,17 @@ void findAndAttachProcess() {
     cerr << "Can't find dolphin. Launch dolphin first!" << endl;
     exit(1);
   }
+
+  if (!getEmuRAMAddressStart()) {
+    // Wait for dolphin to start running a game
+    cout << "Detected dolphin isn't running a game. Waiting for game to start" << endl;
+    while (!getEmuRAMAddressStart())
+      Sleep(1000);
+  }
 }
 
 namespace GameMemory {
-    uint32_t getRealPtr(std::uint32_t address) {
+    uint32_t getRealPtr(uint32_t address) {
       uint32_t masked = address & 0x7FFFFFFF;
       if (masked > 0x1800000) {
         return 0;
@@ -67,24 +109,38 @@ namespace GameMemory {
     }
 
     uint32_t read_u32(uint32_t address) {
+      if (!emuRAMAddressStart)
+        return 0;
+
       uint32_t res = 0;
       SIZE_T read = 0;
-      ReadProcessMemory(dolphinProcHandle, offset + getRealPtr(address), &res, 4, &read);
+      if (ReadProcessMemory(dolphinProcHandle, reinterpret_cast<void*>(emuRAMAddressStart + getRealPtr(address)), &res, 4, &read) == 0) {
+        cerr << "Failed to read memory from" << address << ". Error: " << GetLastError() << endl;
+        return 0;
+      }
+
       if (read != 4) {
         return 0;
       } else {
-        return be32toh(res);
+        return beToHost32(res);
       }
     }
 
     uint64_t read_u64(uint32_t address) {
+      if (!emuRAMAddressStart)
+        return 0;
+
       uint64_t res = 0;
       SIZE_T read = 0;
-      ReadProcessMemory(dolphinProcHandle, offset + getRealPtr(address), &res, 8, &read);
+      if (ReadProcessMemory(dolphinProcHandle, reinterpret_cast<void*>(emuRAMAddressStart + getRealPtr(address)), &res, 8, &read) == 0) {
+        cerr << "Failed to read memory from" << address << ". Error: " << GetLastError() << endl;
+        return 0;
+      }
+
       if (read != 8) {
         return 0;
       } else {
-        return be64toh(res);
+        return beToHost64(res);
       }
     }
 


### PR DESCRIPTION
* Drop Cygwin dependency for windows builds
* Use winsock and other windows API's for windows builds
* Add `PW_USE_LOOPBACK` optional definition to indicate server should only use loopback interface
* Move lean&mean definition to CmakeLists.txt
* Remove privilege request, isn't needed.

Hopefully I didn't break non-windows builds with these changes!